### PR TITLE
Fix sync workflow missing Pages artifact upload steps

### DIFF
--- a/.github/workflows/sync-schedule.yml
+++ b/.github/workflows/sync-schedule.yml
@@ -49,5 +49,14 @@ jobs:
           committer_name: "GitHub Actions"
           committer_email: "actions@github.com"
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The deploy-pages action requires configure-pages and upload-pages-artifact
to run first. Without them the deploy step always failed, leaving the live
site stale after each scheduled sync.

https://claude.ai/code/session_01Du98j5rdS5KtV2EuqW1YsV